### PR TITLE
Update p2.als to properly calculate user permissions

### DIFF
--- a/01-app-and-folder.als
+++ b/01-app-and-folder.als
@@ -1,0 +1,12 @@
+abstract sig Object {}
+
+sig App extends Object {}
+
+sig Folder extends Object {
+    // Folders can contain Apps and other Folders
+    children: set Object,
+}
+
+// You should be able to execute this and see a picture of a filesystem!
+run make_filesystem {
+} for exactly 2 Folder, exactly 1 App

--- a/02-tree.als
+++ b/02-tree.als
@@ -1,0 +1,21 @@
+// Import a module with some properties about graphs and our Object sig, name it `object_graph`
+open util/graph[Object] as object_graph
+
+abstract sig Object {}
+
+sig App extends Object {}
+
+sig Folder extends Object {
+    var children: set Object,
+}
+
+// A `fact` contains booleans that *must* be true. Alloy won't even try to simulate
+// a universe where a fact wouldn't be true.
+fact start_as_a_tree {
+    // Ask the imported module if all our Objects are in a tree
+    object_graph/tree[children]
+}
+
+// Now all the Objects should be in a tree structure!
+run make_filesystem {
+} for exactly 2 Folder, exactly 1 App

--- a/03-root-folder.als
+++ b/03-root-folder.als
@@ -1,0 +1,33 @@
+open util/graph[Object] as object_graph
+
+abstract sig Object {
+    // `private` keyword stops it from cluttering up the diagram
+    var private parent: lone Folder,
+}
+
+sig App extends Object {}
+
+sig Folder extends Object {
+    var children: set Object,
+}
+
+fact start_as_a_tree {
+    object_graph/tree[children]
+}
+
+fact parent_is_opposite_of_children {
+    always {
+        all o: Object {
+            o.parent = {f: Folder | o in f.children}
+        }
+    }
+}
+
+// Always returns the 1 folder that has no parents
+fun root_folder: one Folder {
+    {f: Folder | no f.parent}
+}
+
+// Now the root folder will be labeled!
+run make_filesystem {
+} for exactly 2 Folder, exactly 1 App

--- a/04-permissions.als
+++ b/04-permissions.als
@@ -1,0 +1,35 @@
+open util/graph[Object] as object_graph
+
+abstract sig Object {
+    var private parent: lone Folder,
+}
+
+sig App extends Object {}
+
+sig Folder extends Object {
+    var children: set Object,
+}
+
+fact start_as_a_tree {
+    object_graph/tree[children]
+}
+
+fact parent_is_opposite_of_children {
+    always {
+        all o: Object {
+            o.parent = {f: Folder | o in f.children}
+        }
+    }
+}
+
+fun root_folder: one Folder {
+    {f: Folder | no f.parent}
+}
+
+// Permissions, ordered from weakest to strongest.
+// The lowest permission in Retool is "None", but `none` is a reserved keyword
+// in Alloy. I'm going to use the term `CannotSee` throughout this spec instead.
+private enum Permission { CannotSee, Use, Edit, Own }
+
+run make_filesystem {
+} for exactly 2 Folder, exactly 1 App

--- a/05-groups.als
+++ b/05-groups.als
@@ -1,0 +1,39 @@
+open util/graph[Object] as object_graph
+
+abstract sig Object {
+    var private parent: lone Folder,
+}
+
+sig App extends Object {}
+
+sig Folder extends Object {
+    var children: set Object,
+}
+
+fact start_as_a_tree {
+    object_graph/tree[children]
+}
+
+fact parent_is_opposite_of_children {
+    always {
+        all o: Object {
+            o.parent = {f: Folder | o in f.children}
+        }
+    }
+}
+
+fun root_folder: one Folder {
+    {f: Folder | no f.parent}
+}
+
+private enum Permission { CannotSee, Use, Edit, Own }
+
+sig Group {
+    // A Group has 0 or 1 explicitly granted permissions to each Object
+    // Not using the `var` keyword because explicit permissions won't change over
+    // the course of a simulation
+    explicit: Permission lone -> set Object,
+}
+
+run make_filesystem {
+} for exactly 2 Folder, exactly 1 App, exactly 1 Group

--- a/06-user.als
+++ b/06-user.als
@@ -1,0 +1,45 @@
+open util/graph[Object] as object_graph
+
+abstract sig Object {
+    var private parent: lone Folder,
+}
+
+sig App extends Object {}
+
+sig Folder extends Object {
+    var children: set Object,
+}
+
+fact start_as_a_tree {
+    object_graph/tree[children]
+}
+
+fact parent_is_opposite_of_children {
+    always {
+        all o: Object {
+            o.parent = {f: Folder | o in f.children}
+        }
+    }
+}
+
+fun root_folder: one Folder {
+    {f: Folder | no f.parent}
+}
+
+private enum Permission { CannotSee, Use, Edit, Own }
+
+sig Group {
+    explicit: Permission lone -> set Object,
+}
+
+// For now, we use only one User.
+one sig User {
+    // A User can be a member of multiple Groups
+    groups: set Group,
+    // This relation represents the calculated level of access the User has to
+    // each Object.
+    var calculated: Permission one -> Object,
+}
+
+run make_filesystem {
+} for exactly 2 Folder, exactly 1 App, exactly 1 Group

--- a/07-calculate-perms.als
+++ b/07-calculate-perms.als
@@ -1,0 +1,59 @@
+open util/graph[Object] as object_graph
+
+abstract sig Object {
+    var private parent: lone Folder,
+}
+
+sig App extends Object {}
+
+sig Folder extends Object {
+    var children: set Object,
+}
+
+fact start_as_a_tree {
+    object_graph/tree[children]
+}
+
+fact parent_is_opposite_of_children {
+    always {
+        all o: Object {
+            o.parent = {f: Folder | o in f.children}
+        }
+    }
+}
+
+fun root_folder: one Folder {
+    {f: Folder | no f.parent}
+}
+
+private enum Permission { CannotSee, Use, Edit, Own }
+
+sig Group {
+    explicit: Permission lone -> set Object,
+    var private implicit: Permission one -> set Object,
+}
+
+fact calculate_group_implicit_perms {
+    always {
+        all g: Group {
+            all o: Object {
+                some p : Permission {
+                    o in g.implicit[p] <=> (
+                        o in g.explicit[p] or
+                        some ancestor : Folder {
+                            ancestor in g.explicit[p]
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+one sig User {
+    groups: set Group,
+    var calculated: Permission one -> set Object,
+}
+
+run make_filesystem {
+} for exactly 2 Folder, exactly 1 App, exactly 1 Group

--- a/p2.als
+++ b/p2.als
@@ -1,0 +1,83 @@
+// Import a module with some properties about graphs, name it `object_graph`
+open util/graph[Object] as object_graph
+
+abstract sig Object {}
+
+sig App extends Object {}
+
+sig Folder extends Object {
+    // Folders can contain Apps and other Folders
+    var children: set Object,
+    var parent: lone Object,
+}
+
+// You should be able to execute this and see a picture of a filesystem!
+run make_filesystem {
+} for exactly 2 Folder, exactly 1 App
+
+fact start_as_a_tree {
+    object_graph/tree[children]
+}
+
+fact parent_is_opposite_of_children {
+    always {
+        all o: Object {
+            no o.parent or o in o.parent.children
+        }
+    }
+}
+
+// Always returns exactly 1 folder
+fun root_folder: one Folder {
+    {f: Folder | no f.parent}
+}
+
+// Permissions, ordered from weakest to strongest.
+// The lowest permission in Retool is "None", but `none` is a reserved keyword
+// in Alloy. I'm going to use the term `CannotSee` throughout this spec instead.
+enum Permission { CannotSee, Use, Edit, Own }
+
+sig Group {
+    // A Group has 0 or 1 explicitly granted permissions to each Object
+    // Not using the `var` keyword because this shouldn't change over the course
+    // of a simulation
+    explicit: Permission lone -> set Object,
+    implicit: Permission one -> set Object,
+}
+
+// You can add this to the bottom of your file, or scroll up and fix
+// the original `make_filesystem` command instead
+run make_filesystem_2 {
+} for exactly 2 Folder, exactly 1 App, exactly 1 Group
+
+// For now, we use only one User.
+one sig User {
+    // A User can be a member of multiple Groups
+    groups: set Group,
+    // This relation represents the calculated level of access the User has to
+    // each Object.
+    var calculated: Permission one -> Object,
+}
+
+fact calculate_user_permissions {
+    always {
+        all o: Object {
+            // Return the greatest permission for an object across all of the User's groups
+            let p = ordering/max[{ p: Permission | some g : User.groups | p = group_implicit[g, o] }] {
+                o in User.calculated[p]
+            }
+        }
+    }
+}
+
+// Return the Group's permission to the Object if there is one, or go up the tree
+// and return the first inherited permission you see
+fun group_implicit[g: Group, o: Object]: one Permission {
+    group_implicit[g, parent[o]]
+}
+
+// fact calculate_user_implicit_permissions {
+//     all object: Object |
+//         let strongest_perm = ordering/max[{p: Permission | user_implicit[p, object]}] |
+//             object in implicit[strongest_perm]
+// }

--- a/p2.als
+++ b/p2.als
@@ -1,40 +1,40 @@
-// Import a module with some properties about graphs, name it `object_graph`
-open util/graph[Object] as object_graph
+// Import a module with some properties about graphs
+open util/graph[Object]
 
-abstract sig Object {}
+abstract sig Object {
+    var parent: lone Folder,
+}
 
 sig App extends Object {}
 
 sig Folder extends Object {
     // Folders can contain Apps and other Folders
     var children: set Object,
-    var parent: lone Object,
 }
 
-// You should be able to execute this and see a picture of a filesystem!
-run make_filesystem {
-} for exactly 2 Folder, exactly 1 App
-
-fact start_as_a_tree {
-    object_graph/tree[children]
+one sig RootFolder extends Folder {
 }
 
-fact parent_is_opposite_of_children {
+fact root_folder_has_no_parent {
     always {
-        all o: Object {
-            no o.parent or o in o.parent.children
-        }
+        no RootFolder.parent
     }
 }
 
-// Always returns exactly 1 folder
-fun root_folder: one Folder {
-    {f: Folder | no f.parent}
+fact file_system_starts_as_a_tree {
+    graph/treeRootedAt[children, RootFolder]
+}
+
+fact parent_is_inverse_of_children {
+    always {
+        parent = ~children
+    }
 }
 
 // Permissions, ordered from weakest to strongest.
 // The lowest permission in Retool is "None", but `none` is a reserved keyword
 // in Alloy. I'm going to use the term `CannotSee` throughout this spec instead.
+// Declaring an enum automatically imports the ordering module.
 enum Permission { CannotSee, Use, Edit, Own }
 
 sig Group {
@@ -42,13 +42,26 @@ sig Group {
     // Not using the `var` keyword because this shouldn't change over the course
     // of a simulation
     explicit: Permission lone -> set Object,
-    implicit: Permission one -> set Object,
+    // These result in calculated permissions which *do* change over the course of a simulation.
+    var calculated: Permission one -> set Object,
 }
 
-// You can add this to the bottom of your file, or scroll up and fix
-// the original `make_filesystem` command instead
-run make_filesystem_2 {
-} for exactly 2 Folder, exactly 1 App, exactly 1 Group
+fact calculate_group_permissions {
+    always {
+        all g: Group, p: Permission, o: Object {
+            // A Group's calculated permission to the object is the first explicit permission we find
+            // as we go up the tree
+            o in g.calculated[p] iff {
+                some ancestor: o.*parent {
+                    ancestor in g.explicit[p]
+                    no closer_ancestor: o.*parent & ancestor.^children {
+                        closer_ancestor in g.explicit[Permission]
+                    }
+                }
+            }
+        }
+    }
+}
 
 // For now, we use only one User.
 one sig User {
@@ -56,28 +69,111 @@ one sig User {
     groups: set Group,
     // This relation represents the calculated level of access the User has to
     // each Object.
-    var calculated: Permission one -> Object,
+    var calculated: Permission one -> set Object,
 }
 
 fact calculate_user_permissions {
     always {
         all o: Object {
-            // Return the greatest permission for an object across all of the User's groups
-            let p = ordering/max[{ p: Permission | some g : User.groups | p = group_implicit[g, o] }] {
-                o in User.calculated[p]
+            // A user's calculated Permission to an Object is the greatest Permission to that Object
+            // across all its Groups.
+            //
+            // We are using `max` from the ordering module, which was automatically imported because
+            // Permission is an enum.
+            ~(User.calculated)[o] = ordering/max[{ p: Permission | o in User.groups.calculated[p] } + { CannotSee }]
+        }
+    }
+}
+
+// Describing all of the transitions that occur during a simulation
+// https://haslab.github.io/formal-software-design/modelling-tips/index.html#an-idiom-to-depict-events
+
+enum Event { Stutter, Move }
+
+// A stutter is a transition where nothing changes
+pred stutter {
+    parent' = parent
+}
+
+fun stutter_happens : set Event {
+    { e: Stutter | stutter }
+}
+
+pred move[src: Object, dst: Folder] {
+    // Can't move something into itself or one of its children
+    src not in dst.*parent
+
+    // Not actually moving it if you're already in the destination folder
+    dst not in src.parent
+
+    // User must own both the source and destination
+    src in User.calculated[Own]
+    dst in User.calculated[Own]
+
+    // Change the source's parent
+    parent' = parent - src->src.parent + src->dst
+}
+
+fun move_happens : set Event -> set Object one -> one Folder {
+    { e: Move, src: Object, dst: Folder | move[src, dst] }
+}
+
+fun events : set Event {
+    stutter_happens + move_happens.Object.Folder
+}
+
+fact traces {
+    always some events
+}
+
+run move_an_object {
+    some src: Object, dst: Folder | eventually move[src, dst]
+}
+
+run inherited_permission {
+    some g: Group, o: Object {
+        o not in g.explicit[Own]
+        not o in g.calculated[Own]
+        eventually o in g.calculated[Own]
+    }
+} for 2 Group, 3 Object
+
+check maintains_tree_structure {
+    always graph/treeRootedAt[children, RootFolder]
+}
+
+check calculated_permission_correctness {
+    all g: Group, o: Object, p: Permission {
+        o in g.explicit[p] implies o in g.calculated[p]
+    }
+}
+
+run user_self_grants_own_access {
+    some o: Object {
+        o in User.calculated[CannotSee]
+        eventually o in User.calculated[Own]
+    }
+} for 2 Group, 4 Object, 2 steps
+
+// True iff you can't set a lower permission for a child than its parents have
+pred children_have_greater_perms_than_parent {
+    all g: Group, o: Object, p: Permission {
+        o in g.explicit[p] implies {
+            no greater_perm: ordering/nexts[p] {
+                some o.^parent & g.explicit[greater_perm]
             }
         }
     }
 }
 
-// Return the Group's permission to the Object if there is one, or go up the tree
-// and return the first inherited permission you see
-fun group_implicit[g: Group, o: Object]: one Permission {
-    group_implicit[g, parent[o]]
+// Verify that if children have greater permissions than their parents at the beginning, moving
+// things around can't change that
+check children_always_have_greater_perms_than_parent {
+    children_have_greater_perms_than_parent implies always children_have_greater_perms_than_parent
 }
 
-// fact calculate_user_implicit_permissions {
-//     all object: Object |
-//         let strongest_perm = ordering/max[{p: Permission | user_implicit[p, object]}] |
-//             object in implicit[strongest_perm]
-// }
+// Verify that users can't change their own level of access if we enforce that children must have
+// greater permissions than their parents at the beginning
+check user_cannot_gain_or_lose_access_if_children_have_greater_explicit_perms_than_parents {
+    children_have_greater_perms_than_parent implies User.calculated = User.calculated'
+}

--- a/permissions-model.als
+++ b/permissions-model.als
@@ -79,13 +79,14 @@ one sig User {
     var implicit: Permission one -> Object,
 } {
     all object: Object |
-        let strongest_perm = max[{p: Permission | user_implicit[p, object]}] |
+        let strongest_perm = ordering/max[{p: Permission | user_implicit[p, object]}] |
             object in implicit[strongest_perm]
 }
 
 sig Group {
-    // For each Object, this Group can be explicitly granted at most one Permission
-    explicit: Permission lone -> Object,
+    // For each Object, this Group can be explicitly granted at most one
+    // Permission
+    explicit: Permission lone -> set Object,
 }
 
 /**
@@ -212,7 +213,7 @@ pred children_have_greater_perms_than_parent {
             // If `ancestor` really is a parent, grandparent, etc. of the child, then
             ancestor in child.^parent =>
                 // `ancestor` also has less than or equal permission to the child
-                ancestor_perm in child_perm + prevs[child_perm]
+                ancestor_perm in child_perm + ordering/prevs[child_perm]
         }
 }
 

--- a/permissions-model.thm
+++ b/permissions-model.thm
@@ -8,44 +8,82 @@
 <defaultedge/>
 
 <node>
+   <type name="App"/>
+   <type name="CannotSee"/>
    <type name="Edit"/>
    <type name="Int"/>
-   <type name="None"/>
-   <type name="Object"/>
    <type name="Own"/>
    <type name="String"/>
+   <type name="Stutter"/>
    <type name="univ"/>
    <type name="Use"/>
+   <type name="open$4/Ord"/>
    <type name="ordering/Ord"/>
    <type name="seq/Int"/>
-   <set name="$root_folder" type="Folder"/>
-   <set name="$user_cannot_gain_or_lose_access_inaccessible_object" type="Object"/>
-   <set name="$user_cannot_gain_or_lose_access_missing_perm" type="Permission"/>
+   <set name="$user_self_grants_own_access_o" type="Object"/>
 </node>
 
 <node color="Blue">
-   <type name="Move"/>
+   <type name="Object"/>
 </node>
 
 <node color="Gray">
    <type name="User"/>
 </node>
 
-<node shape="Circle" color="Green">
+<node hideunconnected="no">
+   <type name="RootFolder"/>
+</node>
+
+<node hideunconnected="no" showlabel="no">
+   <set name="$events" type="Event"/>
+</node>
+
+<node hideunconnected="yes" shape="Parallelogram" color="Red">
+   <type name="Event"/>
+</node>
+
+<node shape="Egg" color="Green">
    <type name="Group"/>
 </node>
 
-<node shape="Egg" color="Red">
-   <type name="Page"/>
+<node shape="Ellipse">
+   <type name="Folder"/>
 </node>
 
-<node shape="Ellipse" color="Red">
-   <type name="Folder"/>
+<node style="Dashed" color="Blue">
+   <type name="Move"/>
 </node>
 
 <node visible="no">
    <type name="Permission"/>
 </node>
+
+<node visible="no" showlabel="no">
+   <set name="$stutter_happens" type="Event"/>
+</node>
+
+<edge constraint="no">
+   <relation name="explicit"> <type name="Group"/> <type name="Permission"/> <type name="Object"/> </relation>
+   <relation name="groups"> <type name="User"/> <type name="Group"/> </relation>
+</edge>
+
+<edge style="inherit">
+   <relation name="children"> <type name="Folder"/> <type name="Object"/> </relation>
+</edge>
+
+<edge style="inherit" visible="no" attribute="yes" constraint="no">
+   <relation name="calculated"> <type name="Group"/> <type name="Permission"/> <type name="Object"/> </relation>
+   <relation name="calculated"> <type name="User"/> <type name="Permission"/> <type name="Object"/> </relation>
+</edge>
+
+<edge visible="no">
+   <relation name="parent"> <type name="Object"/> <type name="Folder"/> </relation>
+</edge>
+
+<edge visible="no" attribute="yes" constraint="no" label="args">
+   <relation name="$move_happens"> <type name="Event"/> <type name="Object"/> <type name="Folder"/> </relation>
+</edge>
 
 </view>
 


### PR DESCRIPTION
Update p2.als to properly calculate user permissions

Summary:

Test Plan:

ghstack-source-id: 0b37eed3faccfbbfdd0e0e74060d77b2edcbc2d9
Pull Request resolved: https://github.com/jthemphill/permission-model/pull/5

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/jthemphill/permission-model/pull/5).
* __->__ #5
* #4